### PR TITLE
derive Serialize on some event structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nile-client-rs"
-version = "0.0.1-alpha"
+version = "0.0.1-alpha.1"
 description = "A Rust client for the thenile.dev/"
 documentation = "https://github.com/CoreDB-io/nile-client-rs"
 edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,18 +12,18 @@ pub struct InstanceUpdate {
 
 #[derive(Deserialize, Debug, Serialize)]
 pub struct EntityInstance {
-    id: String,
-    created: String,
-    updated: String,
-    seq: i32,
+    pub id: String,
+    pub created: String,
+    pub updated: String,
+    pub seq: i32,
 
     #[serde(rename = "type")]
-    type_: String,
-    properties: serde_json::Value, // Properties are the entity spec
-    org: String,
+    pub type_: String,
+    pub properties: serde_json::Value, // Properties are the entity spec
+    pub org: String,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 struct AuthResponse {
     token: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,16 @@
 use reqwest;
 use serde;
+use serde::{Deserialize, Serialize};
 use serde_json;
 
-#[derive(serde::Serialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct InstanceUpdate {
     pub op: String,
     pub path: String,
     pub value: String,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct EntityInstance {
     id: String,
     created: String,
@@ -27,14 +28,14 @@ struct AuthResponse {
     token: String,
 }
 
-#[derive(serde::Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Serialize)]
 pub enum EventType {
     CREATE,
     UPDATE,
     DELETE,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct Event {
     pub timestamp: String,
     pub id: i32,


### PR DESCRIPTION
Make it easier to serialize the data in these structs, and makes the attributes on an EntityInstance public so that they can actually be useful outside this crate.