### PR TITLE
deserialize patch response to struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 repo = "https://github.com/CoreDB-io/nile-client-rs"
 
 [dependencies]
+log = "0.4.17"
 reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ NILE_URL=https://prod.thenile.dev
 use std::env;
 
 use dotenv::dotenv;
-use nile_client_rs::{InstanceUpdate, NileClient};
+use nile_client_rs::{EntityInstance, InstanceUpdate, NileClient};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -75,10 +75,10 @@ let status_update = InstanceUpdate {
 updates.push(status_update);
 
 // send the updates to the Nile
-let status = client
+let status: EntityInstance = client
     .patch_instance(&workspace, &org, &entity_name, &instance_id, updates)
     .await?;
-print!("status: {:#?}", status);
+println!("status: {:#?}", status);
 }
 
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@ use reqwest;
 use serde;
 use serde::{Deserialize, Serialize};
 use serde_json;
+use std::error::Error;
+
+use log::error;
 
 #[derive(Serialize, Debug)]
 pub struct InstanceUpdate {
@@ -156,7 +159,7 @@ impl NileClient {
         entity_name: &str,
         instance_id: &str,
         updates: Vec<InstanceUpdate>,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    ) -> Result<EntityInstance, Box<dyn Error>> {
         let uri = format!(
             "{base_url}/workspaces/{workspace}/orgs/{org}/instances/{entity_name}/{id}",
             base_url = self.base_url,
@@ -169,11 +172,19 @@ impl NileClient {
         let resp = client
             .patch(uri)
             .json(&updates)
+            .timeout(std::time::Duration::from_secs(5))
             .header("Authorization", "Bearer ".to_owned() + &self._token)
             .send()
             .await?;
-        let resp_obj = resp.json::<serde_json::Value>().await.unwrap();
-        Ok(resp_obj)
+
+        if resp.status().is_success() {
+            let resp_obj = resp.json::<EntityInstance>().await?;
+            Ok(resp_obj)
+        } else {
+            let errmsg = format!("Error: {}, {}", resp.status().as_u16(), resp.text().await?);
+            error!("{errmsg}");
+            Err(errmsg.into())
+        }
     }
 }
 


### PR DESCRIPTION
Maps the successful responses from instance updates to the `EntityInstance` struct instead of passing them as raw json. Logs error when the call fails.